### PR TITLE
Fixes SNI issues #57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>2.6</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.19</version>
                 <executions>
                     <execution>
                         <goals>
@@ -32,7 +32,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty-version}</version>
                 <configuration>
@@ -42,13 +42,9 @@
                     <webAppSourceDirectory>target/${project.artifactId}-${project.version}</webAppSourceDirectory>
                     <stopPort>8079</stopPort>
                     <stopKey>stopit</stopKey>
-                    <connectors>
-                        <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                            <port>8002</port>
-                            <maxIdleTime>60000</maxIdleTime>
-                            <confidentialPort>8443</confidentialPort>
-                        </connector>
-                    </connectors>
+                    <httpConnector>
+                      <port>${jetty.http.port}</port>
+                    </httpConnector>
                 </configuration>
                 <executions>
                     <execution>
@@ -78,6 +74,12 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <version>${swagger-core-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -86,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <version>${servlet-api-version}</version>
         </dependency>
         <dependency>
@@ -99,19 +101,29 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <!-- <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>$(jackson-version)</version>
+        </dependency> -->
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
             <version>${jersey-version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
             <version>${jersey-version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-servlet</artifactId>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
             <version>${jersey-version}</version>
         </dependency>
         <dependency>
@@ -125,26 +137,54 @@
             <version>${commons-io-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient-version}</version>
+        </dependency>
+        <!-- FIX FOR: Class path contains multiple SLF4J bindings -->
+        <!-- <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion> 
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions> 
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${logback-version}</version>
-        </dependency>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion> 
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions> 
+        </dependency> -->
     </dependencies>
     <properties>
-        <logback-version>1.0.1</logback-version>
-        <jersey-version>1.13</jersey-version>
-        <commons-io-version>2.3</commons-io-version>
+        <jetty.http.port>8002</jetty.http.port>
+        <!-- <logback-version>1.1.3</logback-version> -->
+        <jersey-version>2.22.1</jersey-version>
+        <commons-io-version>2.4</commons-io-version>
+        <httpclient-version>4.5.1</httpclient-version>
         <swagger-core-version>1.5.4</swagger-core-version>
         <swagger-parser-version>1.0.13</swagger-parser-version>
-        <servlet-api-version>2.5</servlet-api-version>
-        <jetty-version>8.1.11.v20130520</jetty-version>
+        <servlet-api-version>3.1.0</servlet-api-version>
+        <jetty-version>9.2.14.v20151106</jetty-version>
         <json-schema-validator-version>2.2.6</json-schema-validator-version>
-        <jackson-version>2.4.5</jackson-version>
+        <jackson-version>2.6.4</jackson-version>
     </properties>
     <repositories>
         <repository>

--- a/src/main/java/io/swagger/validator/ValidatorApplication.java
+++ b/src/main/java/io/swagger/validator/ValidatorApplication.java
@@ -1,0 +1,21 @@
+package io.swagger.validator;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import io.swagger.validator.resources.ValidatorResource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@ApplicationPath("/")
+public class ValidatorApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        final Set<Class<?>> classes = new HashSet<Class<?>>();
+        // register root resource
+        classes.add(ValidatorResource.class);
+        return classes;
+    }
+}

--- a/src/main/java/io/swagger/validator/util/ApiOriginFilter.java
+++ b/src/main/java/io/swagger/validator/util/ApiOriginFilter.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class ApiOriginFilter implements javax.servlet.Filter {
-    @Override
+
     public void doFilter(ServletRequest request, ServletResponse response,
                          FilterChain chain) throws IOException, ServletException {
         HttpServletResponse res = (HttpServletResponse) response;
@@ -35,11 +35,10 @@ public class ApiOriginFilter implements javax.servlet.Filter {
         chain.doFilter(request, response);
     }
 
-    @Override
     public void destroy() {
     }
 
-    @Override
+
     public void init(FilterConfig filterConfig) throws ServletException {
     }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.4"
-         xmlns="http://java.sun.com/xml/ns/j2ee"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee  http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         id="WebApp_ID" version="3.0">
 
     <servlet>
-        <servlet-name>jersey</servlet-name>
-        <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
+        <servlet-name>Jersey REST Service</servlet-name>
+        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
         <init-param>
-            <param-name>com.sun.jersey.config.property.packages</param-name>
+            <param-name>jersey.config.server.provider.packages</param-name>
             <param-value>io.swagger.jaxrs.json;io.swagger.validator.resources</param-value>
         </init-param>
         <init-param>
-            <param-name>com.sun.jersey.spi.container.ContainerRequestFilters</param-name>
-            <param-value>com.sun.jersey.api.container.filter.PostReplaceFilter</param-value>
-        </init-param>
-        <init-param>
-            <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
-            <param-value>true</param-value>
+            <param-name>javax.ws.rs.Application</param-name>
+            <param-value>io.swagger.validator.ValidatorApplication</param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet-mapping>
-        <servlet-name>jersey</servlet-name>
+        <servlet-name>Jersey REST Service</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
-
     <filter>
         <filter-name>ApiOriginFilter</filter-name>
         <filter-class>io.swagger.validator.util.ApiOriginFilter</filter-class>


### PR DESCRIPTION
This will fix issues with Server Name Indication (for example sites using the CloudFlare Flexible SSL service). With this pull request the error `Caused by: javax.net.ssl.SSLException: Received fatal alert: internal_error` for this URL: https://api.rocrooster.net/api-docs.json is gone.

The following things are updated:
* [Maven WAR Plugin](https://maven.apache.org/plugins/maven-war-plugin/) to 2.6
* [Maven Failsafe Plugin](https://maven.apache.org/surefire/maven-failsafe-plugin/) to 2.19
* [Jetty](http://www.eclipse.org/jetty/) to 9.2.14.v20151106
* [javax.servlet](https://docs.oracle.com/javaee/7/api/javax/servlet/package-summary.html) to 3.1.0
* [Jackson Dataformat YAML](https://github.com/FasterXML/jackson-dataformat-yaml) to 2.6.4
* [Jersey](https://jersey.java.net/) to 2.22.1
* [Commons IO](https://commons.apache.org/proper/commons-io/) to 2.4

The following things are changed:
* Used [Apache HttpClient](https://hc.apache.org/httpcomponents-client-ga/index.html) instead of [URLConnection](http://docs.oracle.com/javase/7/docs/api/java/net/URLConnection.html)

I hope you'll like it.