### PR TITLE
Fix dependency version for swagger-parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <commons-io-version>2.4</commons-io-version>
         <httpclient-version>4.5.1</httpclient-version>
         <swagger-core-version>1.5.8</swagger-core-version>
-        <swagger-parser-version>1.0.20-SNAPSHOT</swagger-parser-version>
+        <swagger-parser-version>1.0.20</swagger-parser-version>
         <servlet-api-version>3.1.0</servlet-api-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <json-schema-validator-version>2.2.6</json-schema-validator-version>


### PR DESCRIPTION
Original version with appendix "-SNAPSHOT" was not found in maven central and command "mvn package" failed.