### PR TITLE
Add Content-Type to response

### DIFF
--- a/src/main/java/io/swagger/validator/services/ValidatorService.java
+++ b/src/main/java/io/swagger/validator/services/ValidatorService.java
@@ -263,6 +263,7 @@ public class ValidatorService {
     }
 
     private void writeToResponse(HttpServletResponse response, String name) {
+        response.addHeader("Content-Type", "image/png");
         try {
             InputStream is = this.getClass().getClassLoader().getResourceAsStream(name);
             if (is != null) {


### PR DESCRIPTION
Set `Content-Type` header to `image/png`. Fixes issue where Github failed to cache image because of missing Content-Type header.