### PR TITLE
Refactoring validator spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <jackson.version>2.9.5</jackson.version>
         <httpclient-version>4.5.1</httpclient-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <swagger-parser-version>2.0.0-SNAPSHOT</swagger-parser-version>
+        <swagger-parser-version>2.0.0</swagger-parser-version>
         <swagger-inflector-version>2.0.0-SNAPSHOT</swagger-inflector-version>
         <jetty-version>9.4.9.v20180320</jetty-version>
         <logback-version>1.0.1</logback-version>

--- a/src/main/java/io/swagger/handler/ValidatorController.java
+++ b/src/main/java/io/swagger/handler/ValidatorController.java
@@ -113,6 +113,7 @@ public class ValidatorController{
 
 
         if (valid == true ){
+            //getMediaType() Validate MediaType to set response entity
             return new ResponseContext()
                     .contentType("image/png")
                     .entity(this.getClass().getClassLoader().getResourceAsStream("valid.png"));

--- a/src/main/java/io/swagger/handler/ValidatorController.java
+++ b/src/main/java/io/swagger/handler/ValidatorController.java
@@ -337,7 +337,7 @@ public class ValidatorController{
         }
 
         // use the swagger deserializer to get human-friendly messages
-        if (specVersion.equals("3.0")){
+        if (specVersion.startsWith("3.0")){
             SwaggerParseResult result = readOpenApi(content);
             if(result != null) {
                 for(String message : result.getMessages()) {
@@ -412,7 +412,7 @@ public class ValidatorController{
 
 
         // use the swagger deserializer to get human-friendly messages
-        if (specVersion.equals("3.0")){
+        if (specVersion.startsWith("3.0")){
             SwaggerParseResult result = readOpenApi(content);
             if(result != null) {
                 for(String message : result.getMessages()) {
@@ -472,7 +472,7 @@ public class ValidatorController{
         } catch (Exception e) {
             LOGGER.warn("fetching schema from GitHub");
             InputStream is = null;
-            if (specVersion.equals("3.0")) {
+            if (specVersion.startsWith("3.0")) {
                 is = this.getClass().getClassLoader().getResourceAsStream(SCHEMA_FILE);
             }else if (specVersion.equals("2.0")) {
                 is = this.getClass().getClassLoader().getResourceAsStream(SCHEMA2_FILE);

--- a/src/main/java/io/swagger/handler/ValidatorController.java
+++ b/src/main/java/io/swagger/handler/ValidatorController.java
@@ -12,6 +12,7 @@ import io.swagger.oas.inflector.models.RequestContext;
 import io.swagger.oas.inflector.models.ResponseContext;
 
 import io.swagger.parser.SwaggerParser;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.v3.parser.OpenAPIV3Parser;
@@ -551,7 +552,9 @@ public class ValidatorController{
 
     private SwaggerParseResult readOpenApi(String content) throws IllegalArgumentException {
         OpenAPIV3Parser parser = new OpenAPIV3Parser();
-        return parser.readContents(content, null, null);
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+        return parser.readContents(content, null, options);
 
     }
 

--- a/src/main/java/io/swagger/models/Validation.java
+++ b/src/main/java/io/swagger/models/Validation.java
@@ -1,0 +1,32 @@
+package io.swagger.models;
+
+import java.util.List;
+
+public class Validation {
+        private boolean valid;
+        private List<String> messages;
+
+        public Validation valid(boolean valid) {
+            this.valid = valid;
+            return this;
+        }
+
+
+        public boolean isValid() {
+            return valid;
+        }
+
+        public void setValid(boolean valid) {
+            this.valid = valid;
+        }
+
+
+        public List<String> getMessages() {
+            return messages;
+        }
+
+        public void setMessages(List<String> messages) {
+            this.messages = messages;
+        }
+
+}

--- a/src/main/swagger/swagger.yaml
+++ b/src/main/swagger/swagger.yaml
@@ -25,20 +25,23 @@ paths:
           type: string
       responses:
         '200':
-          description: successfully validated schema
+          description: 'successfully validated schema'
           content:
             "image/png":
               schema:
                 $ref: '#/components/schemas/ImageModel'
             "application/json":
               schema:
-                $ref: '#/components/schemas/ValidModel'
+                $ref: '#/components/schemas/SimpleResponseModel'
         '400':
-          description: 'invalid input schema, or could not be validated'
+          description: 'invalid input schema'
           content:
+            "image/png":
+              schema:
+                $ref: '#/components/schemas/ImageModel'
             "application/json":
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/SimpleResponseModel'
     post:
       tags:
       - Validator
@@ -52,10 +55,10 @@ paths:
         content:
           "application/json":
             schema:
-              $ref: '#/components/schemas/ValidModel'
+              $ref: '#/components/schemas/RequestModel'
           "application/yaml":
             schema:
-              $ref: '#/components/schemas/ValidModel'
+              $ref: '#/components/schemas/RequestModel'
         required: true
       responses:
         '200':
@@ -66,13 +69,13 @@ paths:
                 $ref: '#/components/schemas/ImageModel'
             "application/json":
               schema:
-                $ref: '#/components/schemas/ValidModel'
+                $ref: '#/components/schemas/SimpleResponseModel'
         '400':
           description: 'invalid input schema, or could not be validated'
           content:
             "application/json":
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/SimpleResponseModel'
   "/debug":
       get:
         tags:
@@ -95,13 +98,13 @@ paths:
             content:
               "application/json":
                 schema:
-                  $ref: '#/components/schemas/ValidModel'
+                  $ref: '#/components/schemas/FullResponseModel'
           '400':
             description: 'invalid input schema, or could not be validated'
             content:
               "application/json":
                 schema:
-                  $ref: '#/components/schemas/ErrorModel'
+                  $ref: '#/components/schemas/FullResponseModel'
       post:
         tags:
         - Validator
@@ -115,7 +118,10 @@ paths:
           content:
             "application/json":
               schema:
-                $ref: '#/components/schemas/ValidModel'
+                $ref: '#/components/schemas/RequestModel'
+            "application/yaml":
+              schema:
+                $ref: '#/components/schemas/RequestModel'
           required: true
         responses:
           '200':
@@ -123,26 +129,41 @@ paths:
             content:
               "application/json":
                 schema:
-                  $ref: '#/components/schemas/ValidModel'
+                  $ref: '#/components/schemas/FullResponseModel'
           '400':
             description: 'invalid input schema, or could not be validated'
             content:
               "application/json":
                 schema:
-                  $ref: '#/components/schemas/ErrorModel'
+                  $ref: '#/components/schemas/FullResponseModel'
 
 components:
   schemas:
-    ErrorModel:
+    MessagesModel:
       type: array
-      description: error messages
+      description: Messages
       items:
         type: string
-    ValidModel:
+    SimpleResponseModel:
       type: object
-      properties: {}
-    ImageModel:
+      properties:
+        result:
+          type: string
+          description: the validation result
+          enum:
+            - valid
+            - invalid
+            - error
+            - upgrade
+    FullResponseModel:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        messages:
+          $ref: '#/components/schemas/MessagesModel'
+    ImageResponseModel:
       type: string
       format: binary
-      properties: {}
-
+    RequestModel:
+      type: object

--- a/src/main/swagger/swagger.yaml
+++ b/src/main/swagger/swagger.yaml
@@ -29,7 +29,7 @@ paths:
           content:
             "image/png":
               schema:
-                $ref: '#/components/schemas/ImageModel'
+                $ref: '#/components/schemas/ImageResponseModel'
             "application/json":
               schema:
                 $ref: '#/components/schemas/SimpleResponseModel'
@@ -66,7 +66,7 @@ paths:
           content:
             "image/png":
               schema:
-                $ref: '#/components/schemas/ImageModel'
+                $ref: '#/components/schemas/ImageResponseModel'
             "application/json":
               schema:
                 $ref: '#/components/schemas/SimpleResponseModel'

--- a/src/main/swagger/swagger.yaml
+++ b/src/main/swagger/swagger.yaml
@@ -38,7 +38,7 @@ paths:
           content:
             "image/png":
               schema:
-                $ref: '#/components/schemas/ImageModel'
+                $ref: '#/components/schemas/ImageResponseModel'
             "application/json":
               schema:
                 $ref: '#/components/schemas/SimpleResponseModel'

--- a/src/main/swagger/swagger.yaml
+++ b/src/main/swagger/swagger.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.0
 info:
   title: Swagger Validator Badge
-  description: Validate a 2.x , 3.0.0 specification format
+  description: Validate a 2.0 , 3.0.X specification format
   version: 1.0.0
 servers:
 - url: "/"
@@ -50,9 +50,6 @@ paths:
       requestBody:
         description: the specification to validate
         content:
-          "image/png":
-            schema:
-              $ref: '#/components/schemas/ImageModel'
           "application/json":
             schema:
               $ref: '#/components/schemas/ValidModel'
@@ -64,6 +61,9 @@ paths:
         '200':
           description: successfully validated schema
           content:
+            "image/png":
+              schema:
+                $ref: '#/components/schemas/ImageModel'
             "application/json":
               schema:
                 $ref: '#/components/schemas/ValidModel'

--- a/src/main/swagger/swagger.yaml
+++ b/src/main/swagger/swagger.yaml
@@ -29,21 +29,16 @@ paths:
           content:
             "image/png":
               schema:
-                type: string
-                properties: {}
-            "application/yaml":
+                $ref: '#/components/schemas/ImageModel'
+            "application/json":
               schema:
-                type: object
-                properties: {}
+                $ref: '#/components/schemas/ValidModel'
         '400':
-          description: 'invaild input schema, or could not be validated'
+          description: 'invalid input schema, or could not be validated'
           content:
-            "*/*":
+            "application/json":
               schema:
-                type: array
-                description: error messages
-                items:
-                  type: string
+                $ref: '#/components/schemas/ErrorModel'
     post:
       tags:
       - Validator
@@ -55,14 +50,15 @@ paths:
       requestBody:
         description: the specification to validate
         content:
+          "image/png":
+            schema:
+              $ref: '#/components/schemas/ImageModel'
           "application/json":
             schema:
-              type: object
-              properties: {}
+              $ref: '#/components/schemas/ValidModel'
           "application/yaml":
             schema:
-              type: object
-              properties: {}
+              $ref: '#/components/schemas/ValidModel'
         required: true
       responses:
         '200':
@@ -70,21 +66,13 @@ paths:
           content:
             "application/json":
               schema:
-                type: object
-                properties: {}
-            "application/yaml":
-              schema:
-                type: object
-                properties: {}
+                $ref: '#/components/schemas/ValidModel'
         '400':
-          description: 'invaild input schema, or could not be validated'
+          description: 'invalid input schema, or could not be validated'
           content:
-            "*/*":
+            "application/json":
               schema:
-                type: array
-                description: error messages
-                items:
-                  type: string
+                $ref: '#/components/schemas/ErrorModel'
   "/debug":
       get:
         tags:
@@ -107,21 +95,13 @@ paths:
             content:
               "application/json":
                 schema:
-                  type: object
-                  properties: {}
-              "application/yaml":
-                schema:
-                  type: object
-                  properties: {}
+                  $ref: '#/components/schemas/ValidModel'
           '400':
-            description: 'invaild input schema, or could not be validated'
+            description: 'invalid input schema, or could not be validated'
             content:
-              "*/*":
+              "application/json":
                 schema:
-                  type: array
-                  description: error messages
-                  items:
-                    type: string
+                  $ref: '#/components/schemas/ErrorModel'
       post:
         tags:
         - Validator
@@ -135,12 +115,7 @@ paths:
           content:
             "application/json":
               schema:
-                type: object
-                properties: {}
-            "application/yaml":
-              schema:
-                type: object
-                properties: {}
+                $ref: '#/components/schemas/ValidModel'
           required: true
         responses:
           '200':
@@ -148,19 +123,26 @@ paths:
             content:
               "application/json":
                 schema:
-                  type: object
-                  properties: {}
-              "application/yaml":
-                schema:
-                  type: object
-                  properties: {}
+                  $ref: '#/components/schemas/ValidModel'
           '400':
-            description: 'invaild input schema, or could not be validated'
+            description: 'invalid input schema, or could not be validated'
             content:
-              "*/*":
+              "application/json":
                 schema:
-                  type: array
-                  description: error messages
-                  items:
-                    type: string
-components: {}
+                  $ref: '#/components/schemas/ErrorModel'
+
+components:
+  schemas:
+    ErrorModel:
+      type: array
+      description: error messages
+      items:
+        type: string
+    ValidModel:
+      type: object
+      properties: {}
+    ImageModel:
+      type: string
+      format: binary
+      properties: {}
+


### PR DESCRIPTION
Validating 2.0 and 3.0.X
- Remove YAML responses, it should only return JSON
- Change */* in the response, to JSON.
- Both by URL and by content return either an image or a JSON
- adding format: binary to the image shema
- The JSON/YAML/IMAGE objects were written once under the components and reused across the definition.
- Fix typo in the word 'invaild' - should be 'invalid'