### PR TITLE
Added support for http_proxy and no_proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM openjdk:8-jre-alpine
 
 WORKDIR /validator
 
+COPY docker-entrypoint.sh .
 COPY target/lib/jetty-runner.jar /validator/jetty-runner.jar
 COPY target/*.war /validator/server.war
 COPY src/main/swagger/swagger.yaml /validator/
@@ -11,5 +12,4 @@ ENV REJECT_REDIRECT "true"
 ENV REJECT_LOCAL "true"
 EXPOSE 8080
 
-CMD java -jar -DswaggerUrl=swagger.yaml -DrejectLocal=${REJECT_LOCAL} -DrejectRedirect=${REJECT_REDIRECT} /validator/jetty-runner.jar /validator/server.war
-
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#Automaticly import system proxy settings
+if [ -n "$http_proxy" ] ; then
+    echo $http_proxy | grep "@"
+    if [ $? -eq 0 ]; then # If variable has username and password, its parse method different
+        PROXY_HOST=$(echo $http_proxy | sed 's/http:\/\/.*@\(.*\):.*/\1/')
+        PROXY_PORT=$(echo $http_proxy | sed 's/http:\/\/.*@.*:\(.*\)/\1/' | tr -d "/")
+        USERNAME=$(echo $http_proxy | sed 's/http:\/\/\(.*\)@.*/\1/'|awk -F: '{print $1}')
+        PASSWORD=$(echo $http_proxy | sed 's/http:\/\/\(.*\)@.*/\1/'|awk -F: '{print $2}')
+    else # If it doesn't have username and password, its parse method this
+        PROXY_HOST=$(echo $http_proxy | sed 's/http:\/\/\(.*\):.*/\1/')
+        PROXY_PORT=$(echo $http_proxy | sed 's/http:\/\/.*:\(.*\)/\1/' | tr -d "/")
+    fi
+fi
+
+java -Dhttp.proxyHost=$PROXY_HOST -Dhttp.proxyPort=$PROXY_PORT -Dhttp.proxyUser=$USERNAME -Dhttp.proxyPassword=$PASSWORD -Dhttp.nonProxyHosts=$no_proxy -jar -DswaggerUrl=swagger.yaml -DrejectLocal=$REJECT_LOCAL -DrejectRedirect=$REJECT_REDIRECT /validator/jetty-runner.jar /validator/server.war


### PR DESCRIPTION
Since i need to use validator behind corporate proxy servers. I added support for http_proxy in order to allow validator to pull schemas externally.

