### PR TITLE
refs #187 - fix schema validation, improve exception handling

### DIFF
--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -1,5 +1,6 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
+  "id": "http://swagger.io/v2/schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [


### PR DESCRIPTION
refs #187 - fix schema validation, improve exception handling

includes and replaces #188 by keeping download of external schema but handling correctly schema processing with local schema

see comments in #188.