### PR TITLE
Make webapp validatorUrl self-referential

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -85,6 +85,7 @@
         SwaggerUIBundle.plugins.DownloadUrl
       ],
       layout: "StandaloneLayout",
+      validatorUrl: window.location.protocol + "//" + window.location.host + "/validator",
       queryConfigEnabled: true
     })
 


### PR DESCRIPTION
When deploying application behind a proxy the swagger ui shows "invalid" badge due to application attempting to validate api with validator hosted on http://validator.swagger.io, this change ensures that the swagger ui for the application uses itself to validate.

I posit this should not effect public validator-badge hosted at http://validator.swagger.io as the validator url is currently http://validator.swagger.io and will remain http://validator.swagger.io.